### PR TITLE
Add missing comma on LangDic

### DIFF
--- a/src/LangDic.js
+++ b/src/LangDic.js
@@ -124,7 +124,7 @@ export default {
     'th':'목',
     'fr':'금',
     'sa':'토'
-  }
+  },
   'es' : { // Spanish
     'january':'Enero',
     'february':'Febrero',


### PR DESCRIPTION
```LangDic``` object has missing comma. Causing build script to return error.

Added missing comma on line 127.